### PR TITLE
Switch remaining green styles to red theme

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,7 +52,7 @@ function AppV2() {
         
         {/* Hexagons */}
         <div className="absolute top-20 left-20 w-40 h-40 border border-[#00FFF1]/30 rotate-45"></div>
-        <div className="absolute bottom-20 right-20 w-40 h-40 border border-[#FF003C]/30 rotate-45"></div>
+        <div className="absolute bottom-20 right-20 w-40 h-40 border border-red-500/30 rotate-45"></div>
         <div className="absolute top-1/2 right-1/3 w-20 h-20 border border-[#7DF9FF]/30 rotate-45"></div>
         
         {/* Horizontal scan line effect */}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -21,8 +21,8 @@ const Header: React.FC = () => {
   return (
     <header className="bg-[#1a1a2e] text-white py-4 px-6 shadow-lg sticky top-0 z-50">
       <div className="max-w-7xl mx-auto flex items-center justify-between">
-        <Link to="/" className="flex items-center space-x-2 hover:text-[#39ff14] transition-colors">
-          <Bug className="w-8 h-8 text-[#39ff14]" />
+        <Link to="/" className="flex items-center space-x-2 hover:text-red-500 transition-colors">
+          <Bug className="w-8 h-8 text-red-500" />
           <span className="text-2xl font-bold">Unborked</span>
         </Link>
         
@@ -36,12 +36,12 @@ const Header: React.FC = () => {
         <div className="flex items-center space-x-4">
           <Link
             to="/cart"
-            className="relative hover:text-[#39ff14] transition-colors p-2"
+            className="relative hover:text-red-500 transition-colors p-2"
             data-testid="header-cart-button"
           >
             <ShoppingCart className="w-6 h-6" />
             {itemCount > 0 && (
-              <span className="absolute -top-1 -right-1 bg-[#39ff14] text-[#1a1a2e] rounded-full w-5 h-5 flex items-center justify-center text-xs font-bold">
+              <span className="absolute -top-1 -right-1 bg-red-500 text-[#1a1a2e] rounded-full w-5 h-5 flex items-center justify-center text-xs font-bold">
                 {itemCount}
               </span>
             )}
@@ -50,7 +50,7 @@ const Header: React.FC = () => {
           {isAuthenticated ? (
             <div className="relative">
               <button
-                className="flex items-center space-x-1 hover:text-[#39ff14] transition-colors"
+                className="flex items-center space-x-1 hover:text-red-500 transition-colors"
                 onClick={() => setIsProfileMenuOpen(!isProfileMenuOpen)}
               >
                 <User className="w-5 h-5" />
@@ -71,7 +71,7 @@ const Header: React.FC = () => {
           ) : (
             <Link
               to="/login"
-              className="flex items-center space-x-1 hover:text-[#39ff14] transition-colors"
+              className="flex items-center space-x-1 hover:text-red-500 transition-colors"
             >
               <LogIn className="w-5 h-5" />
               <span className="hidden md:block">Login</span>

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -62,7 +62,7 @@ const ProductCard: React.FC<ProductCardProps> = ({ product }) => {
           <button 
             onClick={handleAddToCart}
             data-testid="add-to-cart-button"
-            className="inline-flex items-center space-x-2 bg-[#1a1a2e] text-white py-2 px-4 rounded hover:bg-[#39ff14] hover:text-[#1a1a2e] transition-colors duration-200"
+            className="inline-flex items-center space-x-2 bg-[#1a1a2e] text-white py-2 px-4 rounded hover:bg-red-500 hover:text-[#1a1a2e] transition-colors duration-200"
           >
             <ShoppingCart className="w-5 h-5 mr-2" />
             <span>Add to Cart</span>

--- a/src/components/VersionIndicator.tsx
+++ b/src/components/VersionIndicator.tsx
@@ -10,13 +10,13 @@ const VersionIndicator: React.FC = () => {
     <div 
       className={`fixed bottom-4 right-4 text-sm font-medium z-50 ${
         isV2 
-          ? 'flex items-center bg-[#0D0221] text-[#00FFF1] border border-[#00FFF1] p-2 font-["Rajdhani",sans-serif] uppercase' 
-          : 'bg-[#39ff14] text-[#1a1a2e] p-2 rounded-full'
+          ? 'flex items-center bg-[#0D0221] text-[#00FFF1] border border-[#00FFF1] p-2 font-["Rajdhani",sans-serif] uppercase'
+          : 'bg-red-500 text-[#1a1a2e] p-2 rounded-full'
       }`}
     >
       {isV2 ? (
         <>
-          <span className="w-2 h-2 bg-[#FF003C] mr-2 animate-pulse"></span>
+          <span className="w-2 h-2 bg-red-500 mr-2 animate-pulse"></span>
           <span>CYBERPUNK.MODE</span>
         </>
       ) : 'Original v1'}

--- a/src/components/v2/HeaderV2.tsx
+++ b/src/components/v2/HeaderV2.tsx
@@ -22,12 +22,12 @@ const HeaderV2: React.FC = () => {
     <header className="bg-[#0D0221] py-4 px-6 sticky top-0 z-50 border-b border-[#00FFF1]/30">
       <div className="max-w-7xl mx-auto flex items-center justify-between">
         <Link to="/" className="flex items-center space-x-2 group">
-          <div className="w-10 h-10 bg-[#0D0221] flex items-center justify-center border border-[#00FFF1] rounded group-hover:border-[#FF003C] transition-colors duration-300 relative">
-            <Bug className="w-6 h-6 text-[#00FFF1] group-hover:text-[#FF003C] transition-colors duration-300" />
+          <div className="w-10 h-10 bg-[#0D0221] flex items-center justify-center border border-[#00FFF1] rounded group-hover:border-red-500 transition-colors duration-300 relative">
+            <Bug className="w-6 h-6 text-[#00FFF1] group-hover:text-red-500 transition-colors duration-300" />
             {/* Glow effect */}
-            <div className="absolute inset-0 rounded bg-[#00FFF1]/20 group-hover:bg-[#FF003C]/20 blur-sm -z-10"></div>
+            <div className="absolute inset-0 rounded bg-[#00FFF1]/20 group-hover:bg-red-500/20 blur-sm -z-10"></div>
           </div>
-          <span className="text-2xl font-bold text-[#00FFF1] group-hover:text-[#FF003C] transition-colors duration-300">UNBORKED</span>
+          <span className="text-2xl font-bold text-[#00FFF1] group-hover:text-red-500 transition-colors duration-300">UNBORKED</span>
         </Link>
         
         {isMenuOpen && (
@@ -39,13 +39,13 @@ const HeaderV2: React.FC = () => {
         <div className="flex items-center space-x-4">
           <Link
             to="/cart"
-            className="relative p-2.5 bg-[#0D0221] border border-[#00FFF1] hover:border-[#FF003C] transition-colors duration-300 group"
+            className="relative p-2.5 bg-[#0D0221] border border-[#00FFF1] hover:border-red-500 transition-colors duration-300 group"
           >
-            <ShoppingCart className="w-6 h-6 text-[#00FFF1] group-hover:text-[#FF003C] transition-colors duration-300" />
+            <ShoppingCart className="w-6 h-6 text-[#00FFF1] group-hover:text-red-500 transition-colors duration-300" />
             {/* Glow effect */}
-            <div className="absolute inset-0 bg-[#00FFF1]/10 group-hover:bg-[#FF003C]/10 -z-10 blur-sm"></div>
+            <div className="absolute inset-0 bg-[#00FFF1]/10 group-hover:bg-red-500/10 -z-10 blur-sm"></div>
             {itemCount > 0 && (
-              <span className="absolute -top-2 -right-2 bg-[#FF003C] text-white border border-[#FF003C] w-6 h-6 flex items-center justify-center text-xs font-bold">
+              <span className="absolute -top-2 -right-2 bg-red-500 text-white border border-red-500 w-6 h-6 flex items-center justify-center text-xs font-bold">
                 {itemCount}
               </span>
             )}
@@ -54,19 +54,19 @@ const HeaderV2: React.FC = () => {
           {isAuthenticated ? (
             <div className="relative">
               <button
-                className="flex items-center space-x-1 text-[#00FFF1] bg-[#0D0221] border border-[#00FFF1] px-4 py-1.5 hover:text-[#FF003C] hover:border-[#FF003C] transition-colors duration-300 group"
+                className="flex items-center space-x-1 text-[#00FFF1] bg-[#0D0221] border border-[#00FFF1] px-4 py-1.5 hover:text-red-500 hover:border-red-500 transition-colors duration-300 group"
                 onClick={() => setIsProfileMenuOpen(!isProfileMenuOpen)}
               >
                 <User className="w-5 h-5" />
                 <span className="hidden md:block">{user?.username}</span>
                 {/* Glow effect */}
-                <div className="absolute inset-0 bg-[#00FFF1]/10 group-hover:bg-[#FF003C]/10 -z-10 blur-sm"></div>
+                <div className="absolute inset-0 bg-[#00FFF1]/10 group-hover:bg-red-500/10 -z-10 blur-sm"></div>
               </button>
               {isProfileMenuOpen && (
                 <div className="absolute right-0 mt-2 w-48 bg-[#0D0221] border border-[#00FFF1] py-1 text-[#00FFF1] z-50">
                   <button
                     onClick={handleLogout}
-                    className="flex w-full items-center px-4 py-2 text-sm hover:bg-[#00FFF1]/10 hover:text-[#FF003C]"
+                    className="flex w-full items-center px-4 py-2 text-sm hover:bg-[#00FFF1]/10 hover:text-red-500"
                   >
                     <LogOut className="w-4 h-4 mr-2" />
                     LOGOUT
@@ -77,26 +77,26 @@ const HeaderV2: React.FC = () => {
           ) : (
             <Link
               to="/login"
-              className="flex items-center space-x-1 text-[#00FFF1] bg-[#0D0221] border border-[#00FFF1] px-4 py-1.5 hover:text-[#FF003C] hover:border-[#FF003C] transition-colors duration-300 group relative"
+              className="flex items-center space-x-1 text-[#00FFF1] bg-[#0D0221] border border-[#00FFF1] px-4 py-1.5 hover:text-red-500 hover:border-red-500 transition-colors duration-300 group relative"
             >
               <LogIn className="w-5 h-5" />
               <span className="hidden md:block">LOGIN</span>
               {/* Glow effect */}
-              <div className="absolute inset-0 bg-[#00FFF1]/10 group-hover:bg-[#FF003C]/10 -z-10 blur-sm"></div>
+              <div className="absolute inset-0 bg-[#00FFF1]/10 group-hover:bg-red-500/10 -z-10 blur-sm"></div>
             </Link>
           )}
 
           <button 
-            className="md:hidden bg-[#0D0221] border border-[#00FFF1] p-1.5 hover:border-[#FF003C] transition-colors duration-300 group relative"
+            className="md:hidden bg-[#0D0221] border border-[#00FFF1] p-1.5 hover:border-red-500 transition-colors duration-300 group relative"
             onClick={() => setIsMenuOpen(!isMenuOpen)}
           >
             {isMenuOpen ? (
-              <X className="w-6 h-6 text-[#00FFF1] group-hover:text-[#FF003C]" />
+              <X className="w-6 h-6 text-[#00FFF1] group-hover:text-red-500" />
             ) : (
-              <Menu className="w-6 h-6 text-[#00FFF1] group-hover:text-[#FF003C]" />
+              <Menu className="w-6 h-6 text-[#00FFF1] group-hover:text-red-500" />
             )}
             {/* Glow effect */}
-            <div className="absolute inset-0 bg-[#00FFF1]/10 group-hover:bg-[#FF003C]/10 -z-10 blur-sm"></div>
+            <div className="absolute inset-0 bg-[#00FFF1]/10 group-hover:bg-red-500/10 -z-10 blur-sm"></div>
           </button>
         </div>
       </div>

--- a/src/components/v2/index.tsx
+++ b/src/components/v2/index.tsx
@@ -15,7 +15,7 @@ const CyberpunkContainer: React.FC<{ children: React.ReactNode }> = ({ children 
     </div>
     
     {/* Hexagon accents */}
-    <div className="fixed bottom-20 right-10 w-40 h-40 border border-[#FF003C]/20 rotate-45 pointer-events-none"></div>
+    <div className="fixed bottom-20 right-10 w-40 h-40 border border-red-500/20 rotate-45 pointer-events-none"></div>
     <div className="fixed top-40 left-10 w-20 h-20 border border-[#00FFF1]/20 rotate-45 pointer-events-none"></div>
     
     <div className="relative z-10 text-gray-200 font-['Rajdhani',sans-serif]">
@@ -45,7 +45,7 @@ const CyberpunkCard: React.FC<{
       <div className="absolute bottom-0 right-0 w-5 h-5 border-b border-r border-[#00FFF1]"></div>
       
       {/* Decorative elements */}
-      <div className="absolute top-2 right-2 w-1.5 h-1.5 bg-[#FF003C]"></div>
+      <div className="absolute top-2 right-2 w-1.5 h-1.5 bg-red-500"></div>
       <div className="h-48 bg-gray-800 relative mb-3 overflow-hidden">
         {image && <img src={image} alt={title} className="w-full h-full object-cover opacity-80 group-hover:opacity-100 transition-opacity" />}
         
@@ -58,7 +58,7 @@ const CyberpunkCard: React.FC<{
       <div className="px-4">
         <h3 className="text-[#00FFF1] text-lg font-bold tracking-wide uppercase">{title}</h3>
         <div className="flex justify-between items-center mt-2">
-          <div className="text-[#FF003C] font-mono font-bold">{price}</div>
+          <div className="text-red-500 font-mono font-bold">{price}</div>
           <div className="relative">
             <button className="cybr-btn text-xs py-1 px-3">SELECT</button>
           </div>
@@ -92,7 +92,7 @@ const CyberpunkHero: React.FC = () => {
           
           {/* Accent lines */}
           <div className="absolute bottom-0 left-0 w-full h-px bg-[#00FFF1]"></div>
-          <div className="absolute top-1/2 right-0 w-20 h-px bg-[#FF003C]"></div>
+          <div className="absolute top-1/2 right-0 w-20 h-px bg-red-500"></div>
           
           {/* Hero content */}
           <div className="absolute inset-0 flex items-center">
@@ -101,7 +101,7 @@ const CyberpunkHero: React.FC = () => {
                 <h1 className="text-5xl font-bold text-white tracking-tight mb-2 uppercase font-['Orbitron',sans-serif]">
                   Buggy code happens; Unbork it
                 </h1>
-                <h2 className="text-3xl font-bold text-[#FF003C] mb-4 font-['Orbitron',sans-serif]">with Developer Swag</h2>
+                <h2 className="text-3xl font-bold text-red-500 mb-4 font-['Orbitron',sans-serif]">with Developer Swag</h2>
                 <p className="text-gray-300 mb-8 max-w-md">
                   Stop screaming in the void and pushing angry commit messages; get back to shipping good vibes today.
                 </p>
@@ -124,7 +124,7 @@ const CyberpunkHero: React.FC = () => {
 const CyberpunkFeaturedProducts: React.FC<{products: any[]}> = ({ products }) => (
   <div id="featured-products" className="container mx-auto px-6 py-16">
     <div className="mb-10 flex items-center">
-      <div className="w-2 h-10 bg-[#FF003C] mr-4"></div>
+      <div className="w-2 h-10 bg-red-500 mr-4"></div>
       <h2 className="text-3xl font-bold text-white uppercase font-['Orbitron',sans-serif] tracking-wide">Featured Products</h2>
     </div>
     
@@ -155,7 +155,7 @@ const CartV2: React.FC = () => (
   <CyberpunkContainer>
     <div className="container mx-auto px-6 py-10">
       <div className="mb-6 flex items-center">
-        <div className="w-2 h-8 bg-[#FF003C] mr-4"></div>
+        <div className="w-2 h-8 bg-red-500 mr-4"></div>
         <h1 className="text-2xl font-bold text-white uppercase font-['Orbitron',sans-serif]">Shopping Cart</h1>
       </div>
       <Cart />
@@ -167,7 +167,7 @@ const LoginV2: React.FC = () => (
   <CyberpunkContainer>
     <div className="container mx-auto px-6 py-10">
       <div className="mb-6 flex items-center">
-        <div className="w-2 h-8 bg-[#FF003C] mr-4"></div>
+        <div className="w-2 h-8 bg-red-500 mr-4"></div>
         <h1 className="text-2xl font-bold text-white uppercase font-['Orbitron',sans-serif]">Login</h1>
       </div>
       <Login />
@@ -179,7 +179,7 @@ const RegisterV2: React.FC = () => (
   <CyberpunkContainer>
     <div className="container mx-auto px-6 py-10">
       <div className="mb-6 flex items-center">
-        <div className="w-2 h-8 bg-[#FF003C] mr-4"></div>
+        <div className="w-2 h-8 bg-red-500 mr-4"></div>
         <h1 className="text-2xl font-bold text-white uppercase font-['Orbitron',sans-serif]">Register</h1>
       </div>
       <Register />
@@ -191,7 +191,7 @@ const ProductDetailV2: React.FC = () => (
   <CyberpunkContainer>
     <div className="container mx-auto px-6 py-10">
       <div className="mb-6 flex items-center">
-        <div className="w-2 h-8 bg-[#FF003C] mr-4"></div>
+        <div className="w-2 h-8 bg-red-500 mr-4"></div>
         <h1 className="text-2xl font-bold text-white uppercase font-['Orbitron',sans-serif]">Product Details</h1>
       </div>
       <ProductDetail />

--- a/src/index.css
+++ b/src/index.css
@@ -95,8 +95,8 @@
 }
 
 .neon-text-danger {
-  color: #FF003C;
-  text-shadow: 0 0 5px #FF003C, 0 0 10px #FF003C;
+  @apply text-red-500;
+  text-shadow: 0 0 5px theme('colors.red.500') , 0 0 10px theme('colors.red.500');
   font-family: 'Orbitron', sans-serif;
 }
 

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -95,7 +95,7 @@ function Cart() {
     return (
       <div className="max-w-7xl mx-auto py-16 px-4">
         <div className="text-center">
-          <div className="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-6 inline-flex items-center mx-auto">
+          <div className="bg-red-500/20 border border-red-500 text-red-500 px-4 py-3 rounded mb-6 inline-flex items-center mx-auto">
             <svg className="w-6 h-6 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 13l4 4L19 7"></path>
             </svg>
@@ -106,7 +106,7 @@ function Cart() {
           <p className="text-gray-600 mb-8">We've sent you a confirmation email with your order details.</p>
           <Link
             to="/"
-            className="bg-[#1a1a2e] text-white px-6 py-3 rounded-lg hover:bg-[#39ff14] hover:text-[#1a1a2e] transition-colors"
+            className="bg-[#1a1a2e] text-white px-6 py-3 rounded-lg hover:bg-red-500 hover:text-[#1a1a2e] transition-colors"
           >
             Continue Shopping
           </Link>
@@ -124,7 +124,7 @@ function Cart() {
           <p className="text-gray-600 mb-8">Looks like your cart needs unborking!</p>
           <Link
             to="/"
-            className="bg-[#1a1a2e] text-white px-6 py-3 rounded-lg hover:bg-[#39ff14] hover:text-[#1a1a2e] transition-colors"
+            className="bg-[#1a1a2e] text-white px-6 py-3 rounded-lg hover:bg-red-500 hover:text-[#1a1a2e] transition-colors"
           >
             Continue Shopping
           </Link>
@@ -165,14 +165,14 @@ function Cart() {
                 <div className="flex items-center space-x-2">
                   <button
                     onClick={() => updateQuantity(item.id.toString(), item.quantity - 1)}
-                    className="p-1 hover:text-[#39ff14]"
+                    className="p-1 hover:text-red-500"
                   >
                     <Minus className="w-4 h-4" />
                   </button>
                   <span className="w-8 text-center">{item.quantity}</span>
                   <button
                     onClick={() => updateQuantity(item.id.toString(), item.quantity + 1)}
-                    className="p-1 hover:text-[#39ff14]"
+                    className="p-1 hover:text-red-500"
                   >
                     <Plus className="w-4 h-4" />
                   </button>
@@ -210,7 +210,7 @@ function Cart() {
             onClick={handleCheckout}
             disabled={isCheckingOut}
             data-testid="checkout-button"
-            className="w-full mt-6 bg-[#1a1a2e] text-white py-3 rounded-lg flex items-center justify-center space-x-2 hover:bg-[#39ff14] hover:text-[#1a1a2e] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            className="w-full mt-6 bg-[#1a1a2e] text-white py-3 rounded-lg flex items-center justify-center space-x-2 hover:bg-red-500 hover:text-[#1a1a2e] transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             <CreditCard className="w-5 h-5" />
             <span>{isCheckingOut ? 'Processing...' : 'Checkout'}</span>

--- a/src/pages/FeatureFlags.tsx
+++ b/src/pages/FeatureFlags.tsx
@@ -261,7 +261,7 @@ export default function FlagsDashboardPage() {
                           {name}
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
-                          <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${value ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-800'}`}>
+                          <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${value ? 'bg-red-500/20 text-red-500' : 'bg-gray-100 text-gray-800'}`}>
                             {value ? 'Enabled' : 'Disabled'}
                           </span>
                         </td>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -47,7 +47,7 @@ function Home() {
             <p className="text-2xl text-gray-200 mb-8">
               Stop screaming in the void and pushing angry commit messages; get back to shipping good vibes today.
             </p>
-            <button className="bg-[#39ff14] text-[#1a1a2e] px-8 py-4 rounded-lg text-lg font-semibold hover:bg-white hover:text-[#1a1a2e] transition-colors duration-300">
+            <button className="bg-red-500 text-[#1a1a2e] px-8 py-4 rounded-lg text-lg font-semibold hover:bg-white hover:text-[#1a1a2e] transition-colors duration-300">
               Shop Solutions
             </button>
           </div>
@@ -61,7 +61,7 @@ function Home() {
         </h2>
         {loading ? (
           <div className="flex justify-center items-center h-64">
-            <div className="animate-spin rounded-full h-16 w-16 border-b-2 border-[#39ff14]"></div>
+            <div className="animate-spin rounded-full h-16 w-16 border-b-2 border-red-500"></div>
           </div>
         ) : error ? (
           <div className="text-center py-10">
@@ -69,7 +69,7 @@ function Home() {
             <p className="text-red-500">{error}</p>
             <button 
               onClick={fetchProducts}
-              className="mt-4 bg-[#1a1a2e] text-white px-4 py-2 rounded hover:bg-[#39ff14] hover:text-[#1a1a2e]"
+              className="mt-4 bg-[#1a1a2e] text-white px-4 py-2 rounded hover:bg-red-500 hover:text-[#1a1a2e]"
             >
               Try Again
             </button>

--- a/src/pages/HomeV2.tsx
+++ b/src/pages/HomeV2.tsx
@@ -58,13 +58,13 @@ function HomeV2() {
         </div>
       ) : error ? (
         <div className="container mx-auto px-6 py-16 text-center">
-          <div className="border border-[#FF003C] p-8 relative">
-            <div className="absolute top-0 left-0 w-5 h-5 border-t border-l border-[#FF003C]"></div>
-            <div className="absolute top-0 right-0 w-5 h-5 border-t border-r border-[#FF003C]"></div>
-            <div className="absolute bottom-0 left-0 w-5 h-5 border-b border-l border-[#FF003C]"></div>
-            <div className="absolute bottom-0 right-0 w-5 h-5 border-b border-r border-[#FF003C]"></div>
+          <div className="border border-red-500 p-8 relative">
+            <div className="absolute top-0 left-0 w-5 h-5 border-t border-l border-red-500"></div>
+            <div className="absolute top-0 right-0 w-5 h-5 border-t border-r border-red-500"></div>
+            <div className="absolute bottom-0 left-0 w-5 h-5 border-b border-l border-red-500"></div>
+            <div className="absolute bottom-0 right-0 w-5 h-5 border-b border-r border-red-500"></div>
             
-            <h3 className="text-[#FF003C] uppercase font-['Orbitron',sans-serif] mb-4">ERROR.DETECTED</h3>
+            <h3 className="text-red-500 uppercase font-['Orbitron',sans-serif] mb-4">ERROR.DETECTED</h3>
             <p className="text-gray-300 mb-6">{error}</p>
             <button 
               onClick={() => window.location.reload()}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -40,7 +40,7 @@ const Login: React.FC = () => {
           <h2 className="text-3xl font-extrabold text-gray-900">Sign in to your account</h2>
           <p className="mt-2 text-gray-600">
             Or{' '}
-            <Link to="/register" className="text-[#39ff14] hover:underline">
+            <Link to="/register" className="text-red-500 hover:underline">
               create a new account
             </Link>
           </p>
@@ -65,7 +65,7 @@ const Login: React.FC = () => {
                 required
                 value={username}
                 onChange={(e) => setUsername(e.target.value)}
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-[#39ff14] focus:border-[#39ff14] focus:z-10"
+                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-red-500 focus:border-red-500 focus:z-10"
                 placeholder="Username"
               />
             </div>
@@ -80,7 +80,7 @@ const Login: React.FC = () => {
                 required
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-[#39ff14] focus:border-[#39ff14] focus:z-10"
+                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-red-500 focus:border-red-500 focus:z-10"
                 placeholder="Password"
               />
             </div>
@@ -90,7 +90,7 @@ const Login: React.FC = () => {
             <button
               type="submit"
               disabled={isLoading}
-              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-[#1a1a2e] hover:bg-[#39ff14] hover:text-[#1a1a2e] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#39ff14] disabled:opacity-50 disabled:cursor-not-allowed"
+              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-[#1a1a2e] hover:bg-red-500 hover:text-[#1a1a2e] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {isLoading ? 'Signing in...' : 'Sign in'}
             </button>

--- a/src/pages/ProductDetail.tsx
+++ b/src/pages/ProductDetail.tsx
@@ -50,7 +50,7 @@ const ProductDetail: React.FC = () => {
   if (loading) {
     return (
       <div className="flex justify-center items-center h-96">
-        <div className="animate-spin rounded-full h-16 w-16 border-b-2 border-[#39ff14]"></div>
+        <div className="animate-spin rounded-full h-16 w-16 border-b-2 border-red-500"></div>
       </div>
     );
   }
@@ -60,7 +60,7 @@ const ProductDetail: React.FC = () => {
       <div className="text-center py-10">
         <h2 className="text-2xl font-bold mb-4">Error</h2>
         <p className="text-red-500">{error || 'Product not found'}</p>
-        <Link to="/" className="inline-block mt-4 text-[#39ff14] hover:underline">
+        <Link to="/" className="inline-block mt-4 text-red-500 hover:underline">
           Back to Products
         </Link>
       </div>
@@ -69,7 +69,7 @@ const ProductDetail: React.FC = () => {
 
   return (
     <div className="container mx-auto px-4 py-8">
-      <Link to="/" className="inline-flex items-center text-[#39ff14] hover:underline mb-6">
+      <Link to="/" className="inline-flex items-center text-red-500 hover:underline mb-6">
         <ArrowLeft className="w-4 h-4 mr-2" />
         Back to Products
       </Link>
@@ -93,7 +93,7 @@ const ProductDetail: React.FC = () => {
             <span className="text-3xl font-bold">${product.price}</span>
             <button
               onClick={handleAddToCart}
-              className="bg-[#1a1a2e] text-white px-6 py-3 rounded-lg flex items-center space-x-2 hover:bg-[#39ff14] hover:text-[#1a1a2e] transition-colors"
+              className="bg-[#1a1a2e] text-white px-6 py-3 rounded-lg flex items-center space-x-2 hover:bg-red-500 hover:text-[#1a1a2e] transition-colors"
             >
               <ShoppingCart className="w-5 h-5" />
               <span>Add to Cart</span>

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -51,7 +51,7 @@ const Register: React.FC = () => {
           <h2 className="text-3xl font-extrabold text-gray-900">Create your account</h2>
           <p className="mt-2 text-gray-600">
             Already have an account?{' '}
-            <Link to="/login" className="text-[#39ff14] hover:underline">
+            <Link to="/login" className="text-red-500 hover:underline">
               Sign in
             </Link>
           </p>
@@ -76,7 +76,7 @@ const Register: React.FC = () => {
                 required
                 value={username}
                 onChange={(e) => setUsername(e.target.value)}
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-[#39ff14] focus:border-[#39ff14] focus:z-10"
+                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-t-md focus:outline-none focus:ring-red-500 focus:border-red-500 focus:z-10"
                 placeholder="Username"
               />
             </div>
@@ -91,7 +91,7 @@ const Register: React.FC = () => {
                 required
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-[#39ff14] focus:border-[#39ff14] focus:z-10"
+                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-red-500 focus:border-red-500 focus:z-10"
                 placeholder="Password"
               />
             </div>
@@ -106,7 +106,7 @@ const Register: React.FC = () => {
                 required
                 value={confirmPassword}
                 onChange={(e) => setConfirmPassword(e.target.value)}
-                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-[#39ff14] focus:border-[#39ff14] focus:z-10"
+                className="appearance-none rounded-none relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 rounded-b-md focus:outline-none focus:ring-red-500 focus:border-red-500 focus:z-10"
                 placeholder="Confirm Password"
               />
             </div>
@@ -116,7 +116,7 @@ const Register: React.FC = () => {
             <button
               type="submit"
               disabled={isLoading}
-              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-[#1a1a2e] hover:bg-[#39ff14] hover:text-[#1a1a2e] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#39ff14] disabled:opacity-50 disabled:cursor-not-allowed"
+              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-[#1a1a2e] hover:bg-red-500 hover:text-[#1a1a2e] focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {isLoading ? 'Creating account...' : 'Create account'}
             </button>


### PR DESCRIPTION
## Summary
- switch leftover green styles to red using Tailwind's built‑in red classes
- update neon-text-danger utility to use Tailwind red color

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*
- `npm run test:checkout` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_68427beffd8c832a9a816c4efa9a6d92